### PR TITLE
Improved 1.19.4 mapping

### DIFF
--- a/mappings/diff/mapping-1.19.4to1.19.3.json
+++ b/mappings/diff/mapping-1.19.4to1.19.3.json
@@ -7,7 +7,7 @@
     "stripped_cherry_log": "stripped_acacia_log[",
     "cherry_wood": "acacia_wood[",
     "stripped_cherry_wood": "stripped_acacia_wood[",
-    "cherry_leaves": "acacia_leaves[",
+    "cherry_leaves": "flowering_azalea_leaves[",
     "torchflower": "red_tulip",
     "cherry_sign": "acacia_sign[",
     "cherry_wall_sign": "acacia_wall_sign[",
@@ -24,7 +24,7 @@
     "cherry_fence_gate": "acacia_fence_gate[",
     "cherry_door": "acacia_door[",
     "torchflower_crop": "melon_stem[",
-    "pink_petals": "air",
+    "pink_petals": "brain_coral_fan",
     "decorated_pot": "bricks"
   },
   "blockentities": {
@@ -39,7 +39,7 @@
     "stripped_cherry_log": "stripped_acacia_log",
     "stripped_cherry_wood": "stripped_acacia_wood",
     "cherry_wood": "acacia_wood",
-    "cherry_leaves": "acacia_leaves",
+    "cherry_leaves": "flowering_azalea_leaves",
     "torchflower": "red_tulip",
     "pink_petals": "brain_coral_fan",
     "cherry_slab": "acacia_slab",


### PR DESCRIPTION
1. If the version is less than 1.19.4, pink_petals cannot be viewed or broken because its blockstate is set to air. I suggest changing the blockstate from air to brain_coral_fan.
![1](https://user-images.githubusercontent.com/89838384/226162498-fc20a9fd-b5e8-451c-b053-5425fe24f2d7.png)

2. cherry_leaves resemble flowering_azalea_leaves more than acacia_leaves.
![2](https://user-images.githubusercontent.com/89838384/226162704-b7583fa5-6c98-457f-8b84-9b08534a5175.png)
