### PR TITLE
fixing oak hanging sign

### DIFF
--- a/mappings/diff/mapping-1.19.3to1.19.json
+++ b/mappings/diff/mapping-1.19.3to1.19.json
@@ -697,7 +697,7 @@
     "bamboo_raft": "birch_boat",
     "bamboo_chest_raft": "birch_chest_boat",
     "bamboo_sign": "birch_sign",
-    "oak_hanging_sign": "birch_sign",
+    "oak_hanging_sign": "oak_sign",
     "spruce_hanging_sign": "spruce_sign",
     "birch_hanging_sign": "birch_sign",
     "jungle_hanging_sign": "jungle_sign",


### PR DESCRIPTION
the oak hanging sign as an item was mapped to the birch sign for some reason