### PR TITLE
Update checkout, JDK and Git config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,8 +61,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "automata"
+          git config --local user.email "action@github.com"
+          git config --local user.name "automation"
           git add .
           git commit -am "Update: ${{ steps.last_snapshot.outputs.content }}"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -20,12 +20,14 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
           distribution: 'temurin'
+          java-version: 17
+          check-latest: true
 
       - name: Setup Maven
-        uses: s4u/setup-maven-action@v1.7.0
+        uses: s4u/setup-maven-action@v1.9.0
         with:
+          java-distribution: 'temurin'
           java-version: 17
 
       - name: Check for snapshot
@@ -59,8 +61,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "automation"
+          git config --local user.email "actions@github.com"
+          git config --local user.name "automata"
           git add .
           git commit -am "Update: ${{ steps.last_snapshot.outputs.content }}"
 


### PR DESCRIPTION
1. Updates the checkout step to v4 and setup-maven-action to 1.9.0,
2. Setup-Java now checks for latest JDK build and will use that instead of having to relay on github default one,
~~3. Updates git config via workflow. *("s" was missing via "action", last part is somewhat memed)*~~

Requires testing before merging at all.