### PR TITLE
Add missing mappings for copper chest variants

### DIFF
--- a/mappings/diff/mapping-1.21.9to1.21.7.json
+++ b/mappings/diff/mapping-1.21.9to1.21.7.json
@@ -214,7 +214,14 @@
   },
   "blocks": {
     "iron_chain": "chain",
-    "copper_chest": "chest"
+    "copper_chest": "chest",
+    "exposed_copper_chest": "chest",
+    "weathered_copper_chest": "chest",
+    "oxidized_copper_chest": "chest",
+    "waxed_copper_chest": "chest",
+    "waxed_exposed_copper_chest": "chest",
+    "waxed_weathered_copper_chest": "chest",
+    "waxed_oxidized_copper_chest": "chest"
   },
   "sounds": {
     "item.armor.equip_copper": "item.armor.equip_iron",


### PR DESCRIPTION
### Description
This PR adds missing block mappings for the various copper chest variants. 

Previously, only the base `copper_chest` was mapped to `chest`. This PR ensures that all oxidation stages (exposed, weathered, oxidized) and their waxed variants are also properly mapped to the standard `chest` block.