### PR TITLE
added a runUi gradle task, fixed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Generates and compiles mapping files for Via*. Current mapping files can be foun
 ## Non-technical editing of existing mappings
 
 If you're just here to edit an existing mapping of a block, item, or an entity name, you can use the helper UI.
-Via IntelliJ or the command line, run `BlockStateMappingUi` main function. After generating the output NBT files,
+Run the `MappingUi` main function via IntelliJ or via the command line with `./gradlew runUi`. After generating the output NBT files,
 you can find them in the `output/` directory.
 
 ## Generating json mapping files for a Minecraft version

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,4 +76,15 @@ tasks {
     test {
         useJUnitPlatform()
     }
+
+    register<JavaExec>("runUi") {
+        group = "application"
+        description = "Starts the mapping helper UI"
+        mainClass.set("com.viaversion.mappingsgenerator.helper.MappingUi")
+        classpath = sourceSets["main"].runtimeClasspath
+        standardInput = System.`in`
+        if (project.hasProperty("args")) {
+            args = (project.property("args") as String).split(" ")
+        }
+    }
 }

--- a/src/main/java/com/viaversion/mappingsgenerator/helper/MappingUi.java
+++ b/src/main/java/com/viaversion/mappingsgenerator/helper/MappingUi.java
@@ -221,11 +221,20 @@ public final class MappingUi {
     }
 
     private static Path ideaProjectsDir() {
+        final Path parent = Path.of("").toAbsolutePath().getParent();
+        if (parent != null && (Files.exists(parent.resolve("ViaVersion")) || Files.exists(parent.resolve("viaversion"))
+            || Files.exists(parent.resolve("ViaBackwards")) || Files.exists(parent.resolve("viabackwards")))) {
+            return parent;
+        }
         return Path.of(System.getProperty("user.home"), "IdeaProjects");
     }
 
     private static Path viaVersionResourceDir() {
-        return ideaProjectsDir().resolve("ViaVersion").resolve("common").resolve("src").resolve("main").resolve("resources")
+        Path base = ideaProjectsDir().resolve("ViaVersion");
+        if (!Files.exists(base)) {
+            base = ideaProjectsDir().resolve("viaversion");
+        }
+        return base.resolve("common").resolve("src").resolve("main").resolve("resources")
             .resolve("assets").resolve("viaversion");
     }
 
@@ -234,7 +243,11 @@ public final class MappingUi {
     }
 
     private static Path viaBackwardsDataDir() {
-        return ideaProjectsDir().resolve("ViaBackwards").resolve("common").resolve("src").resolve("main").resolve("resources")
+        Path base = ideaProjectsDir().resolve("ViaBackwards");
+        if (!Files.exists(base)) {
+            base = ideaProjectsDir().resolve("viabackwards");
+        }
+        return base.resolve("common").resolve("src").resolve("main").resolve("resources")
             .resolve("assets").resolve("viabackwards").resolve("data");
     }
 


### PR DESCRIPTION
This is more of a _proposal_, since we didn't talk beforehand. 

To use the new MappingUI, I wanted a quick way to run the server, but I don't use IntelliJ.

Here's what I updated:
 - Added a `runUi` task in the build file so you can start the UI with one command, `.\gradlew runUi`.
 - Updated MappingUi.java to look for ../ViaVersion & ../ViaBackwards which are needed to run, with all-lowercase or proper casing.
 - Updated README: I couldn't find a reference to BlockStateMappingUi so I assumed that was outdated and also added the new Gradle instructions.