### PR TITLE
Fall back sponge sounds to grass for 1.20.1 and below

### DIFF
--- a/mappings/diff/mapping-1.20.2to1.20.json
+++ b/mappings/diff/mapping-1.20.2to1.20.json
@@ -285,15 +285,15 @@
   },
   "sounds": {
     "block.sponge.absorb": "",
-    "block.sponge.break": "",
-    "block.sponge.fall": "",
-    "block.sponge.hit": "",
-    "block.sponge.place": "",
-    "block.sponge.step": "",
-    "block.wet_sponge.break": "",
-    "block.wet_sponge.fall": "",
-    "block.wet_sponge.hit": "",
-    "block.wet_sponge.place": "",
-    "block.wet_sponge.step": ""
+    "block.sponge.break": "block.grass.break",
+    "block.sponge.fall": "block.grass.fall",
+    "block.sponge.hit": "block.grass.hit",
+    "block.sponge.place": "block.grass.place",
+    "block.sponge.step": "block.grass.step",
+    "block.wet_sponge.break": "block.grass.break",
+    "block.wet_sponge.fall": "block.grass.fall",
+    "block.wet_sponge.hit": "block.grass.hit",
+    "block.wet_sponge.place": "block.grass.place",
+    "block.wet_sponge.step": "block.grass.step"
   }
 }


### PR DESCRIPTION
block.sponge.* and block.wet_sponge.* were added in 1.20.2; mapping them to empty silences sponge interactions entirely for older clients. Both blocks used SoundType.GRASS before 1.20.2, so the grass sounds are what older clients played natively. block.sponge.absorb keeps the drop - its legacy feedback came through levelEvent 2001 rather than a sound event. NOTE that 1.20.1 and below actually DO play a stone.break sound at pitch = 0.8, but that is dictated by the server NOT mappings.